### PR TITLE
update ReadMe with correct preset name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# babel-preset-es2015-loose
+# babel-preset-es2015-webpack-loose
 
 Babel preset that uses [modify-babel-preset] to modify [babel-preset-es2015]
 and enable [loose mode] where available.
@@ -8,7 +8,7 @@ and enable [loose mode] where available.
 Install both this preset, and the core 'babel-preset-es2015' that it modifies:
 
 ```sh
-$ npm install --save-dev babel-preset-es2015-loose babel-preset-es2015
+$ npm install --save-dev babel-preset-es2015-webpack-loose babel-preset-es2015
 ```
 
 ## Usage


### PR DESCRIPTION
I tried installing this npm module using the ReadMe instructions and noticed that it wasn't actually referencing the correct module. I changed it in the README for future users if you're happy to merge this.
